### PR TITLE
Fixed font-weight chrome bug for chrome version 81.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,5 @@
 body{
-    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
+    font-family:"Segoe UI","Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
 }
 
 /* // Extra small devices (portrait phones, less than 576px) */
@@ -291,8 +291,8 @@ body{
 
  #ep-one{
      font-weight: 100;
-     font-size: 90px;
-     letter-spacing: 20px;
+     font-size: 110px;
+     letter-spacing: 22px;
  }
 
  .lead{


### PR DESCRIPTION
Chrome version 81 bug was ignoring css font-weight altogether.

**### My solution after inspecting elements**
`body{
    font-family:"Segoe UI","Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji" !important;
}`
<img width="1246" alt="Chrome 81 Bug Fix" src="https://user-images.githubusercontent.com/30158816/80269431-804c4880-8675-11ea-82e7-8017c754ff16.png">